### PR TITLE
Fix path injection vulnerabilities in file operations

### DIFF
--- a/lib/fileMap.js
+++ b/lib/fileMap.js
@@ -4,12 +4,11 @@ var DATA_ROOT = C.data.root;
 
 exports.filePath = function (relPath, decodeURI) {
   if (decodeURI) relPath = decodeURIComponent(relPath);
-  if (relPath.indexOf('..') >= 0){
-    var e = new Error('Do Not Contain .. in relPath!');
+  var resolved = path.resolve(DATA_ROOT, relPath);
+  if (resolved.indexOf(path.resolve(DATA_ROOT)) !== 0) {
+    var e = new Error('Path traversal detected!');
     e.status = 400;
     throw e;
   }
-  else {
-    return path.join(DATA_ROOT, relPath);
-  }
+  return resolved;
 };

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -39,12 +39,19 @@ router.get('/cf/copy/(.*)', Tools.loadRealPath, function *() {
         if (model.length < 2) {
             return;
         }
-        C.logger.info(`copying from folder:${model[0]} to new folder: ${"/var/www/html/domains/" + model[1]}`);
+        var destBase = "/var/www/html/domains/";
+        var dest = path.resolve(destBase, model[1]);
+        if (dest.indexOf(path.resolve(destBase)) !== 0) {
+            this.status = 400;
+            this.body = 'Invalid destination path';
+            return;
+        }
+        C.logger.info(`copying from folder:${model[0]} to new folder: ${dest}`);
         var ncp = require('ncp').ncp;
 
         ncp.limit = 16;
 
-        ncp(model[0], "/var/www/html/domains/" + model[1], function (err) {
+        ncp(model[0], dest, function (err) {
             if (err) {
                 console.log(err);
                 this.status = 500;


### PR DESCRIPTION
## Summary
- Fixes code scanning alerts [#1](https://github.com/adim/node-file-manager/security/code-scanning/1) and [#2](https://github.com/adim/node-file-manager/security/code-scanning/2) — **path injection** (`js/path-injection`, high severity)
- Replaces the bypassable `..` string check in `filePath()` with `path.resolve()` + prefix validation, ensuring resolved paths cannot escape `DATA_ROOT`
- Adds the same path containment check to the copy-folder route destination

### What was wrong
The old check (`relPath.indexOf('..') >= 0`) could be bypassed via URL-encoded traversal (`%2e%2e`) since `decodeURI` is not always applied before the check. An attacker could read or write arbitrary files on the server via `createReadStream` (line 82) and `createWriteStream` (line 157).

### What this fixes
`path.resolve()` normalizes all path components (including encoded ones) before checking that the result starts with the allowed base directory.

## Test plan
- [ ] Verify normal file browsing/upload/download still works
- [ ] Verify requests with `../` or `%2e%2e` in the path return 400
- [ ] Confirm code scanning alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)