### PR TITLE
Fix path injection via Host header in route handlers

### DIFF
--- a/lib/fileMap.js
+++ b/lib/fileMap.js
@@ -2,6 +2,16 @@ var path = require('path');
 
 var DATA_ROOT = C.data.root;
 
+exports.safeguardPath = function (p) {
+  var resolved = path.resolve(p);
+  if (resolved.indexOf(path.resolve(DATA_ROOT)) !== 0) {
+    var e = new Error('Path traversal detected!');
+    e.status = 400;
+    throw e;
+  }
+  return resolved;
+};
+
 exports.filePath = function (relPath, decodeURI) {
   if (decodeURI) relPath = decodeURIComponent(relPath);
   var resolved = path.resolve(DATA_ROOT, relPath);

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -9,6 +9,7 @@ var formParser = require('co-busboy');
 
 var Tools = require('./tools');
 var FilePath = require('./fileMap').filePath;
+var safeguardPath = require('./fileMap').safeguardPath;
 var FileManager = require('./fileManager');
 
 var router = new koaRouter();
@@ -80,6 +81,7 @@ router.get('/api/(.*)', Tools.loadRealPath, Tools.checkPathExists, function *() 
             }
     }
     console.log("dddddd",p,"type:",this.query.type);
+    p = safeguardPath(p);
     const stats = yield fs.stat(p);
     if (stats.isDirectory()) {
       this.body = yield * FileManager.list(p);
@@ -103,6 +105,7 @@ router.del('/api/(.*)', Tools.loadRealPath, Tools.checkPathExists, function *() 
             p = this.headers['host'] ? pathOnly + Tools.getCleanHostName(this.headers['host']) + "/" + file_name : this.request.fPath;
         }
     }
+  p = safeguardPath(p);
   yield * FileManager.remove(p);
   this.body = 'Delete Succeed!';
 });
@@ -114,6 +117,7 @@ router.put('/api/(.*)', Tools.loadRealPath, Tools.checkPathExists, bodyParser(),
   if (!_.includes(newsetup_domains, this.header['host'])) {
       p = this.headers['host'] ? this.request.fPath + "/" + Tools.getCleanHostName(this.headers['host']) : this.request.fPath;
   }
+  p = safeguardPath(p);
   if (!type) {
     this.status = 400;
     this.body = 'Lack Arg Type'
@@ -148,6 +152,7 @@ router.post('/api/(.*)', Tools.loadRealPath, Tools.checkPathNotExists, bodyParse
     if (!_.includes(newsetup_domains, this.header['host'])) {
         p = this.headers['host'] ? pathOnly + Tools.getCleanHostName(this.headers['host']) + "/" + file_name : this.request.fPath;
     }
+    p = safeguardPath(p);
     console.log("PPPP",p,pathOnly,file_name);
 
     if (!type) {


### PR DESCRIPTION
## Summary
- The previous fix (#16) sanitized paths in `filePath()`, but the route handlers append `this.headers['host']` (user-controlled) to the path **after** sanitization, reintroducing the path injection
- Adds `safeguardPath()` in `fileMap.js` that validates the final resolved path stays within `DATA_ROOT`
- Calls `safeguardPath(p)` before every file operation (`createReadStream`, `createWriteStream`, `remove`, `move`, `rename`, `mkdirs`, `archive`) across all 4 route handlers (GET, DEL, PUT, POST)
- Resolves code scanning alerts [#1](https://github.com/adim/node-file-manager/security/code-scanning/1) and [#2](https://github.com/adim/node-file-manager/security/code-scanning/2)

## Test plan
- [ ] Verify normal file operations still work
- [ ] Verify a crafted Host header with `../` cannot escape DATA_ROOT
- [ ] Confirm code scanning alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)